### PR TITLE
Fixed issue with the inner content wrapping of panels

### DIFF
--- a/js/jquery.liquid-slider.js
+++ b/js/jquery.liquid-slider.js
@@ -744,7 +744,7 @@ if (typeof Object.create !== 'function') {
 
       // Wrap all panels in a div, and wrap inner content in a div (not backwards compatible)
       (self.$panelClass).wrapAll('<div class="panel-container"></div>');
-      (self.$panelClass).wrapInner('<div class="panel-wrapper"></div>');
+      (self.$panelClass).not(':empty').wrapInner('<div class="panel-wrapper"></div>');
       self.panelContainer = (self.$panelClass).parent();
       self.$panelContainer = self.panelContainer;
 


### PR DESCRIPTION
Panels with no inner content were still having their empty content wrapped in a div.  This was also appending child divs on panels with tags such as img which should not have any children.  Added a not empty selector to remove empty panels from the matched elements.
