### PR TITLE
Reworked cross linking 

### DIFF
--- a/js/jquery.liquid-slider.js
+++ b/js/jquery.liquid-slider.js
@@ -1,11 +1,13 @@
 /*!*********************************************************************
 *
-*  Liquid Slider v1.3.6
+*  Liquid Slider v1.3.7
 *  Kevin Batdorf
 *
 *  http://liquidslider.com
 *
 *  GPL license
+*
+* v1.3.7 contains cross link fixes developed by Joe Workman (@joeworkman). The hashCrossLinks setting no longer is used.
 *
 ************************************************************************/
 


### PR DESCRIPTION
Cross Linking was broken in a lot of ways. I think that my changes make cross linking very solid now. My implementation removes the need for the hashCrossLinks setting.  Basically, if crossLinks is enabled, its enabled across the board. If hashNames is enabled, then you can use both #3 and #hash-names. This makes things very flexible. 

I have fully tested this with hashLinks enabled and disabled. 
