### PR TITLE
Add the currentCrossLink class to links pointing to the first class.

### DIFF
--- a/js/jquery.liquid-slider.js
+++ b/js/jquery.liquid-slider.js
@@ -720,7 +720,8 @@ if (typeof Object.create !== 'function') {
               (self.crosslinks).not(self.nextPanel).removeClass('currentCrossLink');
         (self.crosslinks).each(function() {
           if ($(this).attr('href') === ('#' +
-            self.getFromPanel(self.options.panelTitleSelector, self.nextPanel))) {
+            self.getFromPanel(self.options.panelTitleSelector, self.nextPanel ==
+              self.panelCount ? 0 : self.nextPanel))) {
               $(this).addClass('currentCrossLink');
           }
        });


### PR DESCRIPTION
As is, the, currentCrossLink isn't added to links pointing to the first
slide (since a link pointing to the last+1 slide is looked for).

This tiny patch fixes that.
