### PR TITLE
Make it compatible with browser without css animation an jquery.easing

### DIFF
--- a/js/jquery.liquid-slider.js
+++ b/js/jquery.liquid-slider.js
@@ -343,7 +343,7 @@ if (typeof Object.create !== 'function') {
       (self.$sliderId).animate({
         'height': height + 'px'
       }, {
-        easing: easing || self.options.heightEaseFunction,
+        easing: jQuery.easing.hasOwnProperty(easing || self.options.heightEaseFunction) ? easing || self.options.heightEaseFunction : 'swing',
         duration: duration || self.options.heightEaseDuration,
         queue: false
       });
@@ -879,7 +879,7 @@ if (typeof Object.create !== 'function') {
         (self.panelContainer).animate({
           'margin-left': marginLeft + self.pSign
         }, {
-          easing: self.options.slideEaseFunction,
+          easing: jQuery.easing.hasOwnProperty(self.options.slideEaseFunction) ? self.options.slideEaseFunction : 'swing',
           duration: self.options.slideEaseDuration,
           queue: false //,
           //complete: function () {


### PR DESCRIPTION
If a user didn't include `jquery.easing.1.3.js` in their script and use a browser without CSS animation like IE8, a user would receive `Object doesn't support property or method 'easeInOutExpo'` from jQuery and the slider wouldn't run. 

It happens because the liquid slider use the default animation `easeInOutExpo` and since the user didn't include `jquery.easing.1.3.js` the jquery returns an error when trying to use the easing. 

To fix this we can check if jQuery support the easing, if it doesn't we fallback to `swing` easing which is supported by default.

This is not a bug fix, it is more an enhancement to remove the strict requirement of `jquery.easing.1.3.js` script.
