### PR TITLE
Added a fix for the greedy arrows class.

### DIFF
--- a/css/liquid-slider.css
+++ b/css/liquid-slider.css
@@ -177,7 +177,7 @@
 .ls-nav-left-arrow a, .ls-nav-right-arrow a {
   display: block;
 }
-[class$="-arrow"] {
+.ls-wrapper [class$="-arrow"] {
   width: 25px;
   height: 25px;
   background-image: url(../images/arrow.png);


### PR DESCRIPTION
According to https://github.com/KevinBatdorf/liquidslider/blob/master/src/js/jquery.liquid-slider.js#L173-L176 all liquidslider items are wrapped in a div with ls-wrapper.
I added this as a prefix to the arrow class due to the fact that this greedy arrow selector messes up other parts of the site without a liquid slider
By adding the prefix the arrows should stay within their designated area.

![image](https://user-images.githubusercontent.com/8638425/59041506-0b172f80-8879-11e9-98ca-374c5a70ee3f.png)
